### PR TITLE
別リポジトリから呼び出した際、エラーになってしまう問題の修正

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,12 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Set GitHub Path
+      env:
+        GITHUB_ACTION_PATH: ${{ github.action_path }}
+      shell: bash
+      run: echo "$GITHUB_ACTION_PATH" >> $GITHUB_PATH
+
     - name: Check if a github release can be created
       env:
         GH_TOKEN: ${{ inputs.token }}


### PR DESCRIPTION
## 概要
別リポジトリから呼び出した際、下記のエラーとなってしまった。

> bash: can-create-release.bash: No such file or directory

別リポジトリから複合アクションを呼び出すとディレクトリ位置が変わってしまうので、基準となるパスを追記した。


## 参考文献
* [複合アクションを作成する - GitHub Docs](https://docs.github.com/ja/actions/sharing-automations/creating-actions/creating-a-composite-action)
* [ワークフロー実行に関するコンテキスト情報へのアクセス - GitHub Docs](https://docs.github.com/ja/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context)
